### PR TITLE
fix: Corrigir loop de redirecionamento de login

### DIFF
--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -62,10 +62,11 @@ export function AuthProvider({ children }: AuthProviderProps) {
                 setCurrentUser(user);
             } catch (error) {
                 console.error("Error during auth state change:", error);
-                // In case of an error (e.g., Firestore rules, network issue),
-                // set user and profile to null to avoid an inconsistent state.
+                // If profile creation/fetching fails, we should still treat the user as logged in.
+                // The user object from onAuthStateChanged is the source of truth for auth status.
+                // We just might not have a profile in our DB.
+                setCurrentUser(user);
                 setUserProfile(null);
-                setCurrentUser(null);
             } finally {
                 // VERY IMPORTANT: Always set loading to false, even if there's an error.
                 // This prevents the app from getting stuck on the loading screen.


### PR DESCRIPTION
Resolve um bug que fazia com que os utilizadores fossem enviados de volta para a página de login após uma autenticação bem-sucedida.

A causa era um tratamento de erro incorreto no `AuthContext.tsx`, onde uma falha na criação do perfil da Firestore deslogava o utilizador. A lógica foi ajustada para preservar o estado de autenticação do utilizador independentemente do sucesso da operação da base de dados do perfil, o que corrige o loop de redirecionamento.